### PR TITLE
Fix syntax error on Restock Helper

### DIFF
--- a/Restock History.user.js
+++ b/Restock History.user.js
@@ -75,7 +75,7 @@
 
            await updateForeverProfit(-buyPrice);
            await setProfitPerMonth(-buyPrice, today.getMonth(), today.getYear());
-       
+       }
    }
 
 


### PR DESCRIPTION
Re-added } which was accidentally removed in previous commit causing syntax error